### PR TITLE
Add namespace separator at end of Tests namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            ":vendor\\:package_name\\Tests": "tests"
+            ":vendor\\:package_name\\Tests\\": "tests"
         }
     },
     "scripts": {


### PR DESCRIPTION
This wil fix the `A non-empty PSR-4 prefix must end with a namespace separator.` error.